### PR TITLE
feat: Add support for other specs labels & defs (sh, schema, skos)

### DIFF
--- a/aikg/utils/rdf.py
+++ b/aikg/utils/rdf.py
@@ -55,19 +55,25 @@ WHERE
 # Retrieve each subject and its annotations
 SUBJECT_DOC_QUERY = """
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-
-SELECT DISTINCT ?s ?sLab ?sCom
-WHERE
-{{
-    ?s rdfs:label ?sLab .
-    OPTIONAL {{
-        ?s rdfs:comment ?sCom .
-        ?o rdfs:label ?oLab .
-    }}
-    FILTER(LANG(?sLab) = "{lang}" || LANG(?sLab) = "")
-    FILTER(LANG(?sCom) = "{lang}" || LANG(?sLab) = "")
-    {graph_mask}
-}}
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX schema: <http://schema.org/>
+SELECT DISTINCT ?s (SAMPLE(?sLab) as ?sLabel) ?sCom
+WHERE{
+    {
+        VALUES ?labelProp {{skos:prefLabel rdfs:label sh:name schema:name}}
+            VALUES ?defProp {{rdfs:comment skos:definition sh:description schema:description }}
+            {{
+            ?s ?labelProp ?sLab .
+            OPTIONAL {{
+            ?s ?defProp ?sCom .
+        }}
+            FILTER(LANG(?sLab) = "{lang}" || LANG(?sLab) = "")
+            FILTER(LANG(?sCom) = "{lang}" || LANG(?sCom) = "")
+            {graph_mask}
+        }}
+        }}
+            Group by ?s ?sCom
 """
 
 


### PR DESCRIPTION
This PR adds support for a range of semantic properties to describe (label and define) concepts:
- [schema:name](https://schema.org/name) , [sh:name](https://www.w3.org/TR/shacl/#name),[ rdfs:label](https://www.w3.org/TR/rdf-schema/#ch_label), [skos:preLabel](https://www.w3.org/2009/08/skos-reference/skos.html#prefLabel)
- schema:description, sh:description, rdfs:comment, skos:definition (see previous links to find these concepts)